### PR TITLE
Fix players getting stuck in rock in map corners when entering a level

### DIFF
--- a/dat/vaults.des
+++ b/dat/vaults.des
@@ -24,7 +24,6 @@
 #    is a check whether there's actual free space behind the door, outside the room)
 #  - SUBROOM does not work. (causes a crash occasionally. try with fake delphi)
 #  - cannot do split rooms.  (can do, with MAP-ENDMAP & REGIONs)
-#  - Player is occasionally put into a corner of the map. Why?
 #
 # TODO:
 #  - FLAGS: unique

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -471,18 +471,23 @@ flip_level(int flp)
     struct engr *etmp;
     struct mkroom *sroom;
 
-    /* stairs and ladders */
+    /*
+     * stairs and ladders
+     *
+     * DO NOT flip stairs or ladders in the sentinel position (x = 0),
+     * otherwise players will spawn in level corners surrounded by rock.
+     */
     if (flp & 1) {
-	yupstair = y2 - yupstair;
-	ydnstair = y2 - ydnstair;
-	yupladder = y2 - yupladder;
-	ydnladder = y2 - ydnladder;
+	if (xupstair) yupstair = y2 - yupstair;
+	if (xdnstair) ydnstair = y2 - ydnstair;
+	if (xupladder) yupladder = y2 - yupladder;
+	if (xdnladder) ydnladder = y2 - ydnladder;
     }
     if (flp & 2) {
-	xupstair = x2 - xupstair;
-	xdnstair = x2 - xdnstair;
-	xupladder = x2 - xupladder;
-	xdnladder = x2 - xdnladder;
+	if (xupstair) xupstair = x2 - xupstair;
+	if (xdnstair) xdnstair = x2 - xdnstair;
+	if (xupladder) xupladder = x2 - xupladder;
+	if (xdnladder) xdnladder = x2 - xdnladder;
     }
 
     /* traps */


### PR DESCRIPTION
This fixes a bug in level flipping where stairs and ladders in their sentinel positions (i.e. x = 0) were being flipped out of them when SporkHack generated random vaults that allowed the level to be flipped (yes, the placement of a single vault can flip THE ENTIRE LEVEL).

This bug could be seen most often when starting a new game, where the upstair is `sstairs` (special/branch stairs; a comment in `use_defensive()` claims otherwise, but gdb proves it wrong).  The start-of-game code calls `u_on_upstairs()`, which is supposed to put the player on these stairs but instead prioritizes the regular upstairs that have been flipped from x = 0 to x = 79, thus starting the player in the corner of the level surrounded by rock.
